### PR TITLE
fix: storage returns an object even if the provided key doesn't exist

### DIFF
--- a/src/content_script.tsx
+++ b/src/content_script.tsx
@@ -21,7 +21,7 @@ async function retrieveRatesAndChangePage(rateCode: RatesPair) {
 
 async function changeFavouriteRate(ratePair: RatesPair = RatesPair.USDT_ARS) {
   let storage = await chromeExtension.getStorage('favourite-rate');
-  if (!storage) {
+  if (!storage || !storage.hasOwnProperty('favourite-rate')) {
     await chromeExtension.setStorage('favourite-rate', ratePair);
     storage = await chromeExtension.getStorage('favourite-rate');
   }


### PR DESCRIPTION
<img width="1055" alt="image" src="https://user-images.githubusercontent.com/9610178/159917351-3ae9a6ac-dbdf-4735-ad4b-e27674c11f36.png">

`storage` devuelve un objecto y no null/false cuando la clave que le pasas para buscar no existe, haciendo que la porcion de codigo que setea el default cuando no existe nunca se llame